### PR TITLE
refactor(Divider): Replace GSAP with CSS for reveal animation

### DIFF
--- a/src/components/FeaturedProjects.tsx
+++ b/src/components/FeaturedProjects.tsx
@@ -46,7 +46,7 @@ export const FeaturedProjects: React.FC = () => {
         >
             {projects.map((project, index) => (
                 <React.Fragment key={project.id}>
-                    <Divider width="100%" thickness={2} marginY={2} animateFrom={index % 2 ? "right" : "left"} />
+                    <Divider width="100%" thickness={2} marginY={2} />
                     <Box sx={{ display: "grid", gridTemplateColumns: "2fr 3fr 2fr 2fr", ml: "30px", mr: "30px" }}>
                         <Box />
                         {index === 0 ? (
@@ -80,7 +80,7 @@ export const FeaturedProjects: React.FC = () => {
                         />
                     </Box>
                     {projects.length === index + 1 ? (
-                        <Divider width="100%" thickness={2} marginY={2} animateFrom={index % 2 ? "left" : "right"} />
+                        <Divider width="100%" thickness={2} marginY={2} />
                     ) : ( <> </> )}
                 </React.Fragment>
             ))}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -61,7 +61,7 @@ export const Footer: React.FC = () => {
                 userSelect: 'none',
             }}
         >
-            <Divider width="100%" thickness={2} marginY={2} animateFrom="left" />
+            <Divider width="100%" thickness={2} marginY={2} />
             <Box
                 sx={{
                     pt: 8,
@@ -71,7 +71,7 @@ export const Footer: React.FC = () => {
                     <ParallaxText text={'LET’S TALK — LET’S COLLABORATE — SAY HELLO — WANNA BE STARTING SOMETHING? — '} fontSize={'260px'} speed={0} />
                 </Marquee>
             </Box>
-            <Divider width="100%" thickness={2} marginY={2} animateFrom="right" />
+            <Divider width="100%" thickness={2} marginY={2} />
 
             <Email email="robin.bezak.99@gmail.com" />
 

--- a/src/components/OtherProjects.tsx
+++ b/src/components/OtherProjects.tsx
@@ -19,7 +19,7 @@ export const OtherProjects: React.FC = () => {
         >
             {projects.map((project, index) => (
                 <React.Fragment key={index}>
-                    <Divider width="100%" thickness={2} marginY={2} animateFrom={index % 2 ? "right" : "left"} />
+                    <Divider width="100%" thickness={2} marginY={2} />
                     <Box sx={{ display: "grid", gridTemplateColumns: "2fr 3fr 2fr 2fr", ml: "30px", mr: "30px" }}>
                         <Box />
                         <Box />
@@ -47,7 +47,7 @@ export const OtherProjects: React.FC = () => {
                         />
                     </Box>
                     {projects.length === index + 1 ? (
-                        <Divider width="100%" thickness={2} marginY={2} animateFrom={index % 2 ? "left" : "right"} />
+                        <Divider width="100%" thickness={2} marginY={2} />
                     ) : ( <> </> )}
                 </React.Fragment>
             ))}

--- a/src/contexts/DividerDirectionContext.tsx
+++ b/src/contexts/DividerDirectionContext.tsx
@@ -1,0 +1,64 @@
+import React, { createContext, useRef, useCallback, ReactNode, useContext } from 'react';
+
+type AnimationDirection = 'left' | 'right';
+
+interface DividerDirectionContextProps {
+    getNextDirection: () => AnimationDirection;
+}
+
+const DividerDirectionContext = createContext<DividerDirectionContextProps>({
+    getNextDirection: () => 'left',
+});
+
+interface DividerDirectionProviderProps {
+    children: ReactNode;
+}
+
+/**
+ * Provider component for the DividerDirectionContext.
+ * It maintains an array history of assigned directions using useRef
+ * and provides a function (`getNextDirection`) for Dividers to call
+ * to get their animation direction ('left' or 'right').
+ */
+export const DividerDirectionProvider: React.FC<DividerDirectionProviderProps> = ({ children }) => {
+    const historyRef = useRef<AnimationDirection[]>([]);
+
+    /**
+     * Returns the next animation direction ('left' or 'right') based on the
+     * last direction added to the history array. Adds the newly assigned
+     * direction to the history.
+     * Wrapped in useCallback to ensure function identity stability.
+     */
+    const getNextDirection = useCallback((): AnimationDirection => {
+        const history = historyRef.current;
+        const lastDirection: AnimationDirection = history.length > 0 ? history[history.length - 1] : 'right';
+        const newDirection: AnimationDirection = lastDirection === 'left' ? 'right' : 'left';
+
+        history.push(newDirection);
+
+        return newDirection;
+    }, []);
+
+    const contextValue = {
+        getNextDirection,
+    };
+
+    return (
+        <DividerDirectionContext.Provider value={contextValue}>
+            {children}
+        </DividerDirectionContext.Provider>
+    );
+};
+
+/**
+ * Custom hook for easily consuming the DividerDirectionContext.
+ * Provides type safety and hides the useContext implementation detail.
+ * NOTE: We need to import 'useContext' from React for this hook.
+ */
+export const useDividerDirection = (): DividerDirectionContextProps => {
+    const context = useContext(DividerDirectionContext);
+    if (context === undefined) {
+        throw new Error('useDividerDirection must be used within a DividerDirectionProvider');
+    }
+    return context;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,12 +3,15 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
 import { GlobalStyles } from '@mui/material';
+import { DividerDirectionProvider} from "./contexts/DividerDirectionContext.tsx";
 
-const globalFontSmoothing = <GlobalStyles styles={{ body: { '-webkit-font-smoothing': 'antialiased', '-moz-osx-font-smoothing': 'grayscale' } }} />;
+const globalFontSmoothing = <GlobalStyles styles={{ body: { WebkitFontSmoothing: 'antialiased', MozOsxFontSmoothing: 'grayscale' } }} />;
 
 createRoot(document.getElementById('root')!).render(
     <StrictMode>
         {globalFontSmoothing}
-        <App />
+        <DividerDirectionProvider>
+            <App />
+        </DividerDirectionProvider>
     </StrictMode>,
-)
+);


### PR DESCRIPTION
Switches the Divider component's reveal animation from GSAP to a pure CSS keyframe animation (`scaleX`). Uses IntersectionObserver to add a class trigger when the element is visible. Retains context logic for alternating transform-origin. Resolves previous animation inconsistencies.